### PR TITLE
Laat de build falen als Arelle validatiefouten of warnings geeft

### DIFF
--- a/.github/workflows/instance-build.yml
+++ b/.github/workflows/instance-build.yml
@@ -16,7 +16,8 @@ jobs:
     - run: './script/cicd/make-instancelist.bat'
     - run: 'type ./instances/instance_list.env >> $env:GITHUB_ENV'
 
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:INSTANCE_LIST" -v'
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:INSTANCE_LIST" -v --logfile=arelle-instance.log --loglevel=warning'
+    - run: 'script\cicd\catch_errors.bat arelle-instance.log'
 #  --logFile arelle-instance-log.xml
 
 #    - name: Read arelle-instance-log.xml

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,7 +22,7 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v ' --logFile arelle-tax.log
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile arelle-tax.log'
 
     - run: "./script/cicd/catch_errors.bat"
 

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -24,7 +24,9 @@ jobs:
     # validate the taxonomies and load some files ....
     - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile arelle-tax.log'
 
-    - run: './script/cicd/catch_errors.bat'
+    - run: 'script\cicd\catch_errors.bat'
+
+
 #    - name: Read arelle-taxonomy-log.xml
 #      id: package
 #      uses: juliangruber/read-file-action@v1.1.6

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,7 +22,7 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile arelle-tax.log'
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile=arelle-taxo.log'
 
     - run: 'script\cicd\catch_errors.bat'
 

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -25,8 +25,8 @@ jobs:
     # This is how it runs on the server of Githhub, only warnings and errors
     # - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
     # - run: 'script\cicd\catch_errors.bat'
-    # Local you wannt it onscreen
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=info
+    # Local you want it onscreen
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=info'
 
 
 #    - name: Read arelle-taxonomy-log.xml

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     # validate the taxonomies and load some files ....
     - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
-    - run: 'script\cicd\catch_errors.bat'
+    - run: 'script\cicd\catch_errors.bat arelle-taxo.log'
 
 
 #    - name: Read arelle-taxonomy-log.xml

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,7 +22,7 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile=arelle-taxo.log'
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
 
     - run: 'script\cicd\catch_errors.bat'
 

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,9 +22,11 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
-
-    - run: 'script\cicd\catch_errors.bat'
+    # This is how it runs on the server of Githhub, only warnings and errors
+    # - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
+    # - run: 'script\cicd\catch_errors.bat'
+    # Local you wannt it onscreen
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=info
 
 
 #    - name: Read arelle-taxonomy-log.xml

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,11 +22,8 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    # This is how it runs on the server of Githhub, only warnings and errors
-    # - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
-    # - run: 'script\cicd\catch_errors.bat'
-    # Local you want it onscreen
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=info'
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" --validate --logLevel=warning --logFile=arelle-taxo.log'
+    - run: 'script\cicd\catch_errors.bat'
 
 
 #    - name: Read arelle-taxonomy-log.xml

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -24,8 +24,7 @@ jobs:
     # validate the taxonomies and load some files ....
     - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v --logFile arelle-tax.log'
 
-    - run: "./script/cicd/catch_errors.bat"
-
+    - run: './script/cicd/catch_errors.bat'
 #    - name: Read arelle-taxonomy-log.xml
 #      id: package
 #      uses: juliangruber/read-file-action@v1.1.6
@@ -52,6 +51,7 @@ jobs:
         name: taxonomy-packages
         path: |
           ${{ github.workspace }}/artifacts/*.zip
+          ${{ github.workspace }}/arelle-tax.log
 #          ${{ github.workspace }}/artifacts/rj_taxonomy_2024.zip
 #          ${{ github.workspace }}/artifacts/nen_taxonomy_2024.zip
 #          ${{ github.workspace }}/artifacts/iso_taxonomy_2024.zip

--- a/.github/workflows/taxonomy-build.yml
+++ b/.github/workflows/taxonomy-build.yml
@@ -22,8 +22,10 @@ jobs:
     - run: 'type ./taxonomies/entrypoint_list.env >> $env:GITHUB_ENV'
 
     # validate the taxonomies and load some files ....
-    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v ' # --logFile arelle-taxonomy-log.xml
-#
+    - run: './script/arelle/arelleCmdline.exe --packages "$env:PACKAGE_LIST" --file "$env:ENTRYPOINT_LIST" -v ' --logFile arelle-tax.log
+
+    - run: "./script/cicd/catch_errors.bat"
+
 #    - name: Read arelle-taxonomy-log.xml
 #      id: package
 #      uses: juliangruber/read-file-action@v1.1.6

--- a/instances/tst-2.xbrl
+++ b/instances/tst-2.xbrl
@@ -10,6 +10,6 @@
       <xbrli:endDate>2024-12-31</xbrli:endDate>
     </xbrli:period>
   </xbrli:context>
-  <rj_cor:ALMPolicyDescription contextRef="context_1">Dit is testdocument 2</rj_cor:ALMPolicyDescription>
+  <rj_cor:ALMPolicyDescriptio contextRef="context_1">Dit is testdocument 2</rj_cor:ALMPolicyDescriptio>
   <rj_cor:DocumentPresentationCurrency contextRef="context_1">https://xbrl.org/taxonomy/int/currency/2023-01-01/CR/2023-08-23#EUR</rj_cor:DocumentPresentationCurrency>
 </xbrli:xbrl>

--- a/instances/tst-2.xbrl
+++ b/instances/tst-2.xbrl
@@ -10,6 +10,6 @@
       <xbrli:endDate>2024-12-31</xbrli:endDate>
     </xbrli:period>
   </xbrli:context>
-  <rj_cor:ALMPolicyDescriptio contextRef="context_1">Dit is testdocument 2</rj_cor:ALMPolicyDescriptio>
+  <rj_cor:ALMPolicyDescription contextRef="context_1">Dit is testdocument 2</rj_cor:ALMPolicyDescription>
   <rj_cor:DocumentPresentationCurrency contextRef="context_1">https://xbrl.org/taxonomy/int/currency/2023-01-01/CR/2023-08-23#EUR</rj_cor:DocumentPresentationCurrency>
 </xbrli:xbrl>

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal enableDelayedExpansion
+for %%f in (arelle.log) do set "SIZE=%%~zf"
+if "!SIZE!" NEQ "0" (
+  type arelle.log
+  exit /b 1
+) else (
+  echo "Goed hoor"
+)

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -1,4 +1,5 @@
-@echo off
+rem @echo off
+echo "in de navy"
 setlocal enableDelayedExpansion
 for %%f in (arelle-taxo.log) do set "SIZE=%%~zf"
 if "!SIZE!" NEQ "0" (

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -1,8 +1,8 @@
 @echo off
 setlocal enableDelayedExpansion
-for %%f in (arelle.log) do set "SIZE=%%~zf"
+for %%f in (arelle-taxo.log) do set "SIZE=%%~zf"
 if "!SIZE!" NEQ "0" (
-  type arelle.log
+  type arelle-taxo.log
   exit /b 1
 ) else (
   echo "Goed hoor"

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -1,10 +1,9 @@
-rem @echo off
-echo "in de navy"
+@echo off
 setlocal enableDelayedExpansion
 for %%f in (arelle-taxo.log) do set "SIZE=%%~zf"
 if "!SIZE!" NEQ "0" (
   type arelle-taxo.log
   exit /b 1
 ) else (
-  echo "Goed hoor"
+  echo "Arelle says: All good!"
 )

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -1,6 +1,6 @@
 @echo off
 setlocal enableDelayedExpansion
-for %%f in (arelle-taxo.log) do set "SIZE=%%~zf"
+for %%f in (%1) do set "SIZE=%%~zf"
 if "!SIZE!" NEQ "0" (
   type arelle-taxo.log
   exit /b 1

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -5,5 +5,5 @@ if "!SIZE!" NEQ "0" (
   type arelle-taxo.log
   exit /b 1
 ) else (
-  echo "Arelle says: All good!"
+  echo Arelle says: All good! (no warnings or errors^)
 )

--- a/script/cicd/catch_errors.bat
+++ b/script/cicd/catch_errors.bat
@@ -2,7 +2,7 @@
 setlocal enableDelayedExpansion
 for %%f in (%1) do set "SIZE=%%~zf"
 if "!SIZE!" NEQ "0" (
-  type arelle-taxo.log
+  type %1
   exit /b 1
 ) else (
   echo Arelle says: All good! (no warnings or errors^)

--- a/taxonomies/iso_taxonomy_2024/www.iso.org/taxonomy/2025-01-01/iso_19160-4_2023.xsd
+++ b/taxonomies/iso_taxonomy_2024/www.iso.org/taxonomy/2025-01-01/iso_19160-4_2023.xsd
@@ -7,7 +7,7 @@
   <xsd:element name="DescriptionLocationAbroad" id="iso_19160-4_2023_DescriptionLocationAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="HouseNumberAbroad" id="iso_19160-4_2023_HouseNumberAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="NameRegion" id="iso_19160-4_2023_NameRegion" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
-  <xsd:element name="PlaceOfResidenceAbroad" id="iso_19160-4_2023_PlaceOfResidenceAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
+  <xsd:element name="PlaceOfResidenceAbroad" id="iso_19160-4_2023_PlaceOfResidenceAbroad" substitutionGroup="xbrlimp:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="PostalCodeAbroad" id="iso_19160-4_2023_PostalCodeAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="StreetNameAbroad" id="iso_19160-4_2023_StreetNameAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <!-- end of item concepts -->

--- a/taxonomies/iso_taxonomy_2024/www.iso.org/taxonomy/2025-01-01/iso_19160-4_2023.xsd
+++ b/taxonomies/iso_taxonomy_2024/www.iso.org/taxonomy/2025-01-01/iso_19160-4_2023.xsd
@@ -7,7 +7,7 @@
   <xsd:element name="DescriptionLocationAbroad" id="iso_19160-4_2023_DescriptionLocationAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="HouseNumberAbroad" id="iso_19160-4_2023_HouseNumberAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="NameRegion" id="iso_19160-4_2023_NameRegion" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
-  <xsd:element name="PlaceOfResidenceAbroad" id="iso_19160-4_2023_PlaceOfResidenceAbroad" substitutionGroup="xbrlimp:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
+  <xsd:element name="PlaceOfResidenceAbroad" id="iso_19160-4_2023_PlaceOfResidenceAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="PostalCodeAbroad" id="iso_19160-4_2023_PostalCodeAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <xsd:element name="StreetNameAbroad" id="iso_19160-4_2023_StreetNameAbroad" substitutionGroup="xbrli:item" type="xbrli:stringItemType" abstract="false" nillable="true" xbrli:periodType="duration" />
   <!-- end of item concepts -->

--- a/test-package.bat
+++ b/test-package.bat
@@ -14,8 +14,6 @@ set /p TMP_LIST=<taxonomies\entrypoint_list.env
 set "ENTRYPOINT_LIST=%TMP_LIST:~16%"
 
 echo calling Arelle
-.\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!"
-rem "https://www.rjnet.nl/taxonomy/2025-01-01/rj_cor.xsd|
-rem https://www.nen.nl/taxonomy/2025-01-01/nen_1888_2002.xsd|
-rem https://www.nen.nl/taxonomy/2025-01-01/nen_5825_2002.xsd|
-rem https://www.iso.org/taxonomy/2025-01-01/iso_19160-4_2023.xsd"
+for /f %%d in ("arelle.log") do del %%d
+.\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!" --logFile=arelle-taxo.log --logLevel=warning
+type arelle-taxo.log

--- a/test-package.bat
+++ b/test-package.bat
@@ -14,5 +14,5 @@ set /p TMP_LIST=<taxonomies\entrypoint_list.env
 set "ENTRYPOINT_LIST=%TMP_LIST:~16%"
 
 echo calling Arelle
-for /f %%d in ("arelle-taxo.log") do del %%d
+
 .\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!"

--- a/test-package.bat
+++ b/test-package.bat
@@ -14,6 +14,6 @@ set /p TMP_LIST=<taxonomies\entrypoint_list.env
 set "ENTRYPOINT_LIST=%TMP_LIST:~16%"
 
 echo calling Arelle
-for /f %%d in ("arelle.log") do del %%d
+for /f %%d in ("arelle-taxo.log") do del %%d
 .\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!" --logFile=arelle-taxo.log --logLevel=warning
 type arelle-taxo.log

--- a/test-package.bat
+++ b/test-package.bat
@@ -15,5 +15,4 @@ set "ENTRYPOINT_LIST=%TMP_LIST:~16%"
 
 echo calling Arelle
 for /f %%d in ("arelle-taxo.log") do del %%d
-.\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!" --logFile=arelle-taxo.log --logLevel=warning
-type arelle-taxo.log
+.\script\arelle\arelleCmdLine.exe --validate --file="!ENTRYPOINT_LIST!" --packages "!PACKAGE_LIST!"


### PR DESCRIPTION
Arelle geeft standaard exitcode 0, ook als de command-line tool fouten constateert in een aangeboden taxonomie of instance. Wel kunnen we de output opvangen en filteren. Voorlopig vangen we warnings en hoger bij zowel de taxonomie-build als de instance-test. Als Arelle nu iets ziet dat niet in de haak is, dan verschijnt dat in de logfile die we vervolgens lezen.
Wanneer de logfile inhoud heeft stoppen we de build en keren terug met een error, which is what we want.

Lokaal doen we het net even anders, daar laten we de volledige info en hoger over het scherm rollen.

